### PR TITLE
Add http-basic authentication function

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -6,5 +6,5 @@
 (define build-deps '("scribble-lib" "racket-doc"))
 (define scribblings '(("scribblings/simple-http.scrbl" ())))
 (define pkg-desc "Simple interface for making HTTP requests")
-(define version "0.2.1")
+(define version "0.2.2")
 (define pkg-authors '(Darren_N))

--- a/main.rkt
+++ b/main.rkt
@@ -382,9 +382,7 @@
   (check-equal?
    (requester-headers hdrs2)
    '("Accept: text/html; charset=utf-8"
-     "Authorization: Basic Zm9vOmJhcg=="
-     "X-Bar: Bar"
-     "X-Foo: Foo"))
+     "Authorization: Basic Zm9vOmJhcg=="))
   
   (define ssl0 (update-ssl json-requester #t))
   (check-equal? (requester-ssl ssl0) #t)

--- a/scribblings/simple-http.scrbl
+++ b/scribblings/simple-http.scrbl
@@ -124,6 +124,18 @@ relevant data such as base url, use SSL, etc.
   @racket[(update-headers req '("Authorization: 8675309" "x-foo: oof"))]
 }
 
+@defproc[(authenticate-basic
+          [requester requester?]
+          [username string?]
+          [password string?])
+         requester?]{
+  Constructs an http-basic header from @racket[username] and
+  @racket[password], and then merges that header into the headers of
+  the @racket[requester] using @racket[update-headers].
+
+  @racket[(authenticate-basic req "sam@example.com" "opensesame")]
+}
+
 @section{Making requests}
 
 Requests are made using requesters to determine how data should be sent and


### PR DESCRIPTION
Hi there, love the library. One convenience function I miss is the ability to create a basic http authentication header. I took inspiration from the httr library for R (http://httr.r-lib.org/) to implement the authenticate-basic function.

I updated the docs and tests to cover this case, and bumped the version. Please let me know if I've forgotten anything, and thanks for the library!